### PR TITLE
PR: Replace *pre-commit* with *prek*.

### DIFF
--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -23,10 +23,6 @@ jobs:
           # https://github.com/scipy/scipy/issues/20613
           echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
         shell: bash
-      - name: Set up Python 3.10 for Pre-Commit
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -39,9 +35,10 @@ jobs:
         run: |
           uv sync --all-extras
         shell: bash
-      - name: Pre-Commit (All Files)
+      - name: Prek (All Files)
+        if: matrix.os == 'macOS-latest'
         run: |
-          uv run pre-commit run --all-files
+          uv run prek run --all-files
         shell: bash
       - name: Test Optimised Python Execution
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "hatch",
     "invoke",
     "jupyter",
-    "pre-commit",
+    "prek",
     "pyright",
     "pytest",
     "pytest-cov<7.0.0",

--- a/tasks.py
+++ b/tasks.py
@@ -45,7 +45,7 @@ __all__ = [
     "clean",
     "formatting",
     "quality",
-    "precommit",
+    "prek",
     "tests",
     "examples",
     "preflight",
@@ -264,9 +264,9 @@ def quality(
 
 
 @task
-def precommit(ctx: Context) -> None:
+def prek(ctx: Context) -> None:
     """
-    Run the "pre-commit" hooks on the codebase.
+    Run the "prek" hooks on the codebase.
 
     Parameters
     ----------
@@ -274,8 +274,8 @@ def precommit(ctx: Context) -> None:
         Context.
     """
 
-    message_box('Running "pre-commit" hooks on the codebase...')
-    ctx.run("pre-commit run --all-files")
+    message_box('Running "prek" hooks on the codebase...')
+    ctx.run("prek run --all-files")
 
 
 @task
@@ -330,7 +330,7 @@ def examples(ctx: Context, plots: bool = False) -> None:
             ctx.run(f"python {os.path.join(root, filename)}")
 
 
-@task(formatting, quality, precommit, tests, examples)
+@task(formatting, quality, prek, tests, examples)
 def preflight(ctx: Context) -> None:  # noqa: ARG001
     """
     Perform the preflight tasks.


### PR DESCRIPTION
# Summary

This PR migrates the project from using `pre-commit` to `prek` for managing git hooks.

# Preflight

**Code Style and Quality**

- [N/A] Unit tests have been implemented and passed.
- [N/A] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is Sphinx and numpydoc compliant.